### PR TITLE
feat: Optional DynamoDB and tf syntax updates

### DIFF
--- a/bucket.tf
+++ b/bucket.tf
@@ -2,14 +2,18 @@
 # create an S3 bucket to store the state file in
 resource "aws_s3_bucket" "terraform_state_storage_s3" {
   bucket = format("%s-tfstate", var.aws_account_name)
-  versioning {
-    enabled = true
-  }
   lifecycle {
     prevent_destroy = true
   }
   tags = {
     Name = "S3 Remote Terraform State Store"
+  }
+}
+
+resource "aws_s3_bucket_versioning" "terraform_state_storage_s3" {
+  bucket = aws_s3_bucket.terraform_state_storage_s3.id
+  versioning_configuration {
+    status = "Enabled"
   }
 }
 

--- a/dynamodb.tf
+++ b/dynamodb.tf
@@ -1,4 +1,5 @@
 resource "aws_dynamodb_table" "dynamodb-terraform-state-lock" {
+  count          = var.dynamodb_lock ? 1 : 0
   name           = format("%s-tfstate-lock", var.aws_account_name)
   hash_key       = "LockID"
   read_capacity  = 2

--- a/variables.tf
+++ b/variables.tf
@@ -1,3 +1,9 @@
 variable "aws_account_name" {
   type = string
 }
+
+variable "dynamodb_lock" {
+  description = "Deploy a DynamoDB table for state locking"
+  type        = bool
+  default     = false
+}


### PR DESCRIPTION
- Makes DynamodDB optional, as it's deprecated https://developer.hashicorp.com/terraform/language/backend/s3#state-locking
- Updates bucket versioning configuration, current configuration was also deprecated

/kind feature
/kind fix
/priority important-longterm
/assign